### PR TITLE
Cache HunspellDictionary in static property for 50x speedup

### DIFF
--- a/SlovakAnalyzer/SlovakAnalyzer/SlovakAnalyzer.csproj
+++ b/SlovakAnalyzer/SlovakAnalyzer/SlovakAnalyzer.csproj
@@ -7,8 +7,8 @@
     <Authors>https://github.com/ksichtik</Authors>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/ksichtik/Lucene.Net.SlovakAnalyzer</PackageProjectUrl>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.0.0</FileVersion>
+    <AssemblyVersion>3.1.0.0</AssemblyVersion>
+    <FileVersion>3.1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SlovakAnalyzer/Test/SlovakAnalyzerTest.csproj
+++ b/SlovakAnalyzer/Test/SlovakAnalyzerTest.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net6.0</TargetFramework>
+		<StartupObject></StartupObject>
+	</PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />


### PR DESCRIPTION
With caching Hunspell dictionary we see at least 50x speed improvement tokenizing with SlovakAnalyzer